### PR TITLE
Release 0.1.1

### DIFF
--- a/.github/project.yml
+++ b/.github/project.yml
@@ -1,5 +1,5 @@
 name: Quarkus OIDC Proxy
 release:
-  current-version: "0.1.0"
+  current-version: "0.1.1"
   next-version: 999-SNAPSHOT
 


### PR DESCRIPTION
I was thinking of 0.2.0, but since it has not got any user feedback yet and it is just the minor doc updates and a version bump from 3.9.0.CR2 to 3.9.0. 
If you think  it should be `0.2.0` then I will do it :-)