### PR TITLE
Fix HtmlUnit coordinates

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -45,7 +45,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
             <scope>test</scope>
         </dependency>

--- a/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
+++ b/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
@@ -2,14 +2,13 @@ package io.quarkus.oidc.proxy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
-
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.QuarkusDevModeTest;
 
@@ -40,7 +39,7 @@ public class OidcProxyTestCase {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("web-app: ID alice, service: Bearer alice", textPage.getContent());
 

--- a/deployment/src/test/resources/application.properties
+++ b/deployment/src/test/resources/application.properties
@@ -6,3 +6,4 @@ quarkus.oidc.web-app.application-type=web-app
 quarkus.oidc.web-app.authentication.cookie-path=/web-app
 quarkus.rest-client.service-api-client.url=http://localhost:8080/service
 
+quarkus.log.category."org.htmlunit".level=ERROR

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -75,8 +75,9 @@ Start by adding the following dependencies to your test project:
 [source.xml]
 ----
 <dependency>
-    <groupId>net.sourceforge.htmlunit</groupId>
+    <groupId>org.htmlunit</groupId>
     <artifactId>htmlunit</artifactId>
+    <version>4.8.0</version>
     <scope>test</scope>
 </dependency>
 <dependency>
@@ -95,11 +96,11 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -119,7 +120,7 @@ public class OidcProxyTestCase {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("web-app: ID alice, service: Bearer alice", textPage.getContent());
 

--- a/integration-tests/pom.xml
+++ b/integration-tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>io.quarkiverse.oidc-proxy</groupId>
     <artifactId>quarkus-oidc-proxy-parent</artifactId>
-    <version>0.1.0-SNAPSHOT</version>
+    <version>999-SNAPSHOT</version>
   </parent>
   <artifactId>quarkus-oidc-proxy-integration-tests</artifactId>
   <name>Quarkus - OIDC Proxy - Integration Tests</name>
@@ -31,7 +31,7 @@
           <scope>test</scope>
       </dependency>
       <dependency>
-          <groupId>net.sourceforge.htmlunit</groupId>
+          <groupId>org.htmlunit</groupId>
           <artifactId>htmlunit</artifactId>
           <scope>test</scope>
       </dependency>

--- a/integration-tests/src/main/java/io/quarkus/oidc/proxy/OidcServiceResource.java
+++ b/integration-tests/src/main/java/io/quarkus/oidc/proxy/OidcServiceResource.java
@@ -8,17 +8,19 @@ import jakarta.ws.rs.Produces;
 import org.eclipse.microprofile.jwt.JsonWebToken;
 
 import io.quarkus.security.Authenticated;
+import io.quarkus.security.identity.SecurityIdentity;
 
 @Path("/service")
 @Authenticated
 public class OidcServiceResource {
 
     @Inject
-    JsonWebToken accessToken;
+    SecurityIdentity accessToken;
 
     @GET
     @Produces("text/plain")
     public String getName() {
-        return accessToken.getClaim("typ") + " " + accessToken.getName();
+        JsonWebToken jwt = accessToken.getPrincipal(JsonWebToken.class);
+        return jwt.getClaim("typ") + " " + jwt.getName();
     }
 }

--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -12,3 +12,4 @@ quarkus.oidc-proxy.external-redirect-uri=http://localhost:8081/web-app
 quarkus.oidc-proxy.external-client-id=external-client-id
 quarkus.oidc-proxy.external-client-secret=external-client-secret
 
+quarkus.log.category."org.htmlunit".level=ERROR

--- a/integration-tests/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
+++ b/integration-tests/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
@@ -2,13 +2,12 @@ package io.quarkus.oidc.proxy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
 import org.junit.jupiter.api.Test;
-
-import com.gargoylesoftware.htmlunit.SilentCssErrorHandler;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlForm;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
 
 import io.quarkus.test.junit.QuarkusTest;
 
@@ -28,7 +27,7 @@ public class OidcProxyTestCase {
             loginForm.getInputByName("username").setValueAttribute("alice");
             loginForm.getInputByName("password").setValueAttribute("alice");
 
-            TextPage textPage = loginForm.getInputByName("login").click();
+            TextPage textPage = loginForm.getButtonByName("login").click();
 
             assertEquals("web-app: ID alice, service: Bearer alice", textPage.getContent());
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
   <modules>
     <module>deployment</module>
     <module>runtime</module>
+    <module>integration-tests</module>
   </modules>
   <scm>
     <connection>scm:git:git@github.com:quarkiverse/quarkus-oidc-proxy.git</connection>
@@ -23,7 +24,7 @@
   </scm>
   <properties>
     <quarkus.version>3.18.3</quarkus.version>
-    <htmlunit.version>2.70.0</htmlunit.version>
+    <htmlunit.version>4.8.0</htmlunit.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -40,7 +41,7 @@
         <version>${project.version}</version>
       </dependency>
       <dependency>
-        <groupId>net.sourceforge.htmlunit</groupId>
+        <groupId>org.htmlunit</groupId>
         <artifactId>htmlunit</artifactId>
         <version>${htmlunit.version}</version>
       </dependency>


### PR DESCRIPTION
Fixes #51

I had to tune the integration test a bit but it is 100% not related to the way OIDC proxy works.

There is a little side-effect here due to the hardening fix Michal helped to do in Quarkus OIDC. During the authorization code flow, ID token is a primary one, access token is meant to be propagated to the downstream service - so it is not verified by default since Quarkus does not use for any security decisions.
Users can request to verify the access token as well.
However, If they don't, and if we detect that `JsonWebToken` without the `@IdToken` qualifier is injected, we try to harden it and enforce the access token verification anyway.
So here in this test a frontend web-app application forwards an access token to the service application, with both endpoints included in the same test, and the service one injects `JsonWebToken` access token - which triggers the verification.
But the OIDC web-app configuration expects a specific audience while the access token does not have it and the test fails...

So I tuned a test a bit to avoid this side-effect...