### PR TITLE
Remove httpRootPath prefix from routes

### DIFF
--- a/deployment/src/main/java/io/quarkus/oidc/proxy/deployment/OidcProxyBuildStep.java
+++ b/deployment/src/main/java/io/quarkus/oidc/proxy/deployment/OidcProxyBuildStep.java
@@ -8,8 +8,10 @@ import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.deployment.util.UriNormalizationUtil;
 import io.quarkus.oidc.proxy.runtime.OidcProxyRecorder;
 import io.quarkus.vertx.http.deployment.VertxWebRouterBuildItem;
+import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 
 @BuildSteps(onlyIf = OidcProxyBuildStep.IsEnabled.class)
 public class OidcProxyBuildStep {
@@ -23,8 +25,10 @@ public class OidcProxyBuildStep {
     public void setup(
             OidcProxyRecorder recorder,
             VertxWebRouterBuildItem vertxWebRouterBuildItem,
+            HttpBuildTimeConfig httpBuildTimeConfig,
             BeanContainerBuildItem beanContainerBuildItem) {
-        recorder.setupRoutes(beanContainerBuildItem.getValue(), vertxWebRouterBuildItem.getHttpRouter());
+        recorder.setupRoutes(beanContainerBuildItem.getValue(), vertxWebRouterBuildItem.getHttpRouter(),
+                UriNormalizationUtil.toURI(httpBuildTimeConfig.rootPath, false).toString());
     }
 
     public static class IsEnabled implements BooleanSupplier {

--- a/deployment/src/main/java/io/quarkus/oidc/proxy/deployment/OidcProxyBuildStep.java
+++ b/deployment/src/main/java/io/quarkus/oidc/proxy/deployment/OidcProxyBuildStep.java
@@ -8,10 +8,8 @@ import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.util.UriNormalizationUtil;
 import io.quarkus.oidc.proxy.runtime.OidcProxyRecorder;
 import io.quarkus.vertx.http.deployment.VertxWebRouterBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 
 @BuildSteps(onlyIf = OidcProxyBuildStep.IsEnabled.class)
 public class OidcProxyBuildStep {
@@ -25,10 +23,8 @@ public class OidcProxyBuildStep {
     public void setup(
             OidcProxyRecorder recorder,
             VertxWebRouterBuildItem vertxWebRouterBuildItem,
-            HttpBuildTimeConfig httpBuildTimeConfig,
             BeanContainerBuildItem beanContainerBuildItem) {
-        recorder.setupRoutes(beanContainerBuildItem.getValue(), vertxWebRouterBuildItem.getHttpRouter(),
-                UriNormalizationUtil.toURI(httpBuildTimeConfig.rootPath, false).toString());
+        recorder.setupRoutes(beanContainerBuildItem.getValue(), vertxWebRouterBuildItem.getHttpRouter());
     }
 
     public static class IsEnabled implements BooleanSupplier {

--- a/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyHttpRootPathTestCase.java
+++ b/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyHttpRootPathTestCase.java
@@ -1,0 +1,57 @@
+package io.quarkus.oidc.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+
+public class OidcProxyHttpRootPathTestCase {
+
+    private static Class<?>[] testClasses = {
+            OidcServiceResource.class,
+            OidcWebAppResource.class,
+            ServiceApiClient.class
+    };
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(testClasses)
+                    .addAsResource("application-http-root-path.properties", "application.properties"));
+
+    @Test
+    public void testOidcProxy() throws Exception {
+
+        try (final WebClient webClient = createWebClient()) {
+            HtmlPage page = webClient.getPage("http://localhost:8080/my-custom-root-path/web-app");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            TextPage textPage = loginForm.getButtonByName("login").click();
+
+            assertEquals("web-app: ID alice, service: Bearer alice", textPage.getContent());
+
+            webClient.getCookieManager().clearCookies();
+        }
+
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+
+}

--- a/deployment/src/test/resources/application-http-root-path.properties
+++ b/deployment/src/test/resources/application-http-root-path.properties
@@ -1,0 +1,10 @@
+quarkus.http.root-path=/my-custom-root-path
+
+quarkus.oidc.web-app.auth-server-url=http://localhost:8080/my-custom-root-path/q/oidc
+quarkus.oidc.web-app.client-id=${quarkus.oidc.client-id}
+quarkus.oidc.web-app.credentials.secret=secret
+quarkus.oidc.web-app.application-type=web-app
+quarkus.oidc.web-app.authentication.cookie-path=/my-custom-root-path/web-app
+quarkus.rest-client.service-api-client.url=http://localhost:8080/my-custom-root-path/service
+
+quarkus.log.category."org.htmlunit".level=ERROR

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
@@ -44,8 +44,9 @@ public class OidcProxy {
     final OidcProxyConfig oidcProxyConfig;
     final WebClient client;
     final String configuredClientSecret;
+    final String httpRootPath;
 
-    public OidcProxy(TenantConfigBean tenantConfig, OidcProxyConfig oidcProxyConfig) {
+    public OidcProxy(TenantConfigBean tenantConfig, OidcProxyConfig oidcProxyConfig, String httpRootPath) {
         TenantConfigContext tenantConfigContext = oidcProxyConfig.tenantId().isEmpty() ? tenantConfig.getDefaultTenant()
                 : tenantConfig.getStaticTenantsConfig().get(oidcProxyConfig.tenantId().get());
         this.oidcTenantConfig = tenantConfigContext.getOidcTenantConfig();
@@ -53,6 +54,7 @@ public class OidcProxy {
         this.client = tenantConfigContext.getOidcProviderClient().getWebClient();
         this.oidcProxyConfig = oidcProxyConfig;
         this.configuredClientSecret = OidcCommonUtils.clientSecret(oidcTenantConfig.credentials);
+        this.httpRootPath = httpRootPath;
     }
 
     public void setup(Router router) {
@@ -511,6 +513,7 @@ public class OidcProxy {
                 : context.request().scheme();
         return new StringBuilder(scheme).append("://")
                 .append(authority)
+                .append(httpRootPath)
                 .append(path)
                 .toString();
     }

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
@@ -55,7 +55,7 @@ public class OidcProxy {
         this.configuredClientSecret = OidcCommonUtils.clientSecret(oidcTenantConfig.credentials);
     }
 
-    public void setup(Router router, String httpRootPath) {
+    public void setup(Router router) {
         if (oidcTenantConfig.applicationType.orElse(ApplicationType.SERVICE) == ApplicationType.WEB_APP) {
             throw new ConfigurationException("OIDC Proxy can only be used with OIDC service applications");
         }
@@ -72,16 +72,16 @@ public class OidcProxy {
             throw new ConfigurationException(
                     "Unsupported OIDC service client authentication method");
         }
-        router.get(httpRootPath + oidcProxyConfig.rootPath() + OidcConstants.WELL_KNOWN_CONFIGURATION)
+        router.get(oidcProxyConfig.rootPath() + OidcConstants.WELL_KNOWN_CONFIGURATION)
                 .handler(this::wellKnownConfig);
         if (oidcMetadata.getJsonWebKeySetUri() != null) {
-            router.get(httpRootPath + oidcProxyConfig.rootPath() + oidcProxyConfig.jwksPath()).handler(this::jwks);
+            router.get(oidcProxyConfig.rootPath() + oidcProxyConfig.jwksPath()).handler(this::jwks);
         }
         if (oidcMetadata.getUserInfoUri() != null && oidcProxyConfig.allowIdToken()) {
-            router.get(httpRootPath + oidcProxyConfig.rootPath() + oidcProxyConfig.userInfoPath()).handler(this::userinfo);
+            router.get(oidcProxyConfig.rootPath() + oidcProxyConfig.userInfoPath()).handler(this::userinfo);
         }
-        router.get(httpRootPath + oidcProxyConfig.rootPath() + oidcProxyConfig.authorizationPath()).handler(this::authorize);
-        router.post(httpRootPath + oidcProxyConfig.rootPath() + oidcProxyConfig.tokenPath()).handler(this::token);
+        router.get(oidcProxyConfig.rootPath() + oidcProxyConfig.authorizationPath()).handler(this::authorize);
+        router.post(oidcProxyConfig.rootPath() + oidcProxyConfig.tokenPath()).handler(this::token);
         if (oidcTenantConfig.authentication.redirectPath.isPresent()) {
             if (!oidcProxyConfig.externalRedirectUri().isPresent()) {
                 throw new ConfigurationException("oidc-proxy.external-redirect-uri property must be configured because"
@@ -91,7 +91,7 @@ public class OidcProxy {
         }
 
         if (oidcMetadata.getEndSessionUri() != null) {
-            router.get(httpRootPath + oidcProxyConfig.rootPath() + oidcProxyConfig.endSessionPath()).handler(this::endSession);
+            router.get(oidcProxyConfig.rootPath() + oidcProxyConfig.endSessionPath()).handler(this::endSession);
             if (oidcTenantConfig.logout().postLogoutPath().isPresent()) {
                 if (!oidcProxyConfig.externalPostLogoutUri().isPresent()) {
                     throw new ConfigurationException("oidc-proxy.external-post-logout-uri property must be configured because"

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyRecorder.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyRecorder.java
@@ -15,10 +15,10 @@ public class OidcProxyRecorder {
         this.oidcProxyConfig = oidcProxyConfig;
     }
 
-    public void setupRoutes(BeanContainer beanContainer, RuntimeValue<Router> routerValue, String httpRootPath) {
+    public void setupRoutes(BeanContainer beanContainer, RuntimeValue<Router> routerValue) {
         TenantConfigBean oidcTenantBean = beanContainer.beanInstance(TenantConfigBean.class);
         OidcProxy proxy = new OidcProxy(oidcTenantBean, oidcProxyConfig.getValue());
         Router router = routerValue.getValue();
-        proxy.setup(router, httpRootPath);
+        proxy.setup(router);
     }
 }

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyRecorder.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyRecorder.java
@@ -15,9 +15,9 @@ public class OidcProxyRecorder {
         this.oidcProxyConfig = oidcProxyConfig;
     }
 
-    public void setupRoutes(BeanContainer beanContainer, RuntimeValue<Router> routerValue) {
+    public void setupRoutes(BeanContainer beanContainer, RuntimeValue<Router> routerValue, String httpRootPath) {
         TenantConfigBean oidcTenantBean = beanContainer.beanInstance(TenantConfigBean.class);
-        OidcProxy proxy = new OidcProxy(oidcTenantBean, oidcProxyConfig.getValue());
+        OidcProxy proxy = new OidcProxy(oidcTenantBean, oidcProxyConfig.getValue(), httpRootPath);
         Router router = routerValue.getValue();
         proxy.setup(router);
     }


### PR DESCRIPTION
Fixes https://github.com/quarkiverse/quarkus-oidc-proxy/issues/70

Removes the `httpRootPath` prefix from quarkus-oidc-proxy routes as Quarkus already does this automatically.