### PR TITLE
[3.15] Remove httpRootPath prefix from routes

### DIFF
--- a/deployment/src/main/java/io/quarkus/oidc/proxy/deployment/OidcProxyBuildStep.java
+++ b/deployment/src/main/java/io/quarkus/oidc/proxy/deployment/OidcProxyBuildStep.java
@@ -8,10 +8,8 @@ import io.quarkus.deployment.annotations.BuildSteps;
 import io.quarkus.deployment.annotations.ExecutionTime;
 import io.quarkus.deployment.annotations.Record;
 import io.quarkus.deployment.builditem.FeatureBuildItem;
-import io.quarkus.deployment.util.UriNormalizationUtil;
 import io.quarkus.oidc.proxy.runtime.OidcProxyRecorder;
 import io.quarkus.vertx.http.deployment.VertxWebRouterBuildItem;
-import io.quarkus.vertx.http.runtime.HttpBuildTimeConfig;
 
 @BuildSteps(onlyIf = OidcProxyBuildStep.IsEnabled.class)
 public class OidcProxyBuildStep {
@@ -25,10 +23,8 @@ public class OidcProxyBuildStep {
     public void setup(
             OidcProxyRecorder recorder,
             VertxWebRouterBuildItem vertxWebRouterBuildItem,
-            HttpBuildTimeConfig httpBuildTimeConfig,
             BeanContainerBuildItem beanContainerBuildItem) {
-        recorder.setupRoutes(beanContainerBuildItem.getValue(), vertxWebRouterBuildItem.getHttpRouter(),
-                UriNormalizationUtil.toURI(httpBuildTimeConfig.rootPath, false).toString());
+        recorder.setupRoutes(beanContainerBuildItem.getValue(), vertxWebRouterBuildItem.getHttpRouter());
     }
 
     public static class IsEnabled implements BooleanSupplier {

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
@@ -54,7 +54,7 @@ public class OidcProxy {
         this.configuredClientSecret = OidcCommonUtils.clientSecret(oidcTenantConfig.credentials);
     }
 
-    public void setup(Router router, String httpRootPath) {
+    public void setup(Router router) {
         if (oidcTenantConfig.applicationType.orElse(ApplicationType.SERVICE) == ApplicationType.WEB_APP) {
             throw new ConfigurationException("OIDC Proxy can only be used with OIDC service applications");
         }
@@ -76,18 +76,18 @@ public class OidcProxy {
                 throw new ConfigurationException("oidc-proxy.external-redirect-uri property must be configured because"
                         + "the local quarkus.oidc.authentication.redirect-path is configured");
             }
-            router.get(httpRootPath + oidcTenantConfig.authentication.redirectPath.get()).handler(this::localRedirect);
+            router.get(oidcTenantConfig.authentication.redirectPath.get()).handler(this::localRedirect);
         }
-        router.get(httpRootPath + oidcProxyConfig.rootPath() + OidcConstants.WELL_KNOWN_CONFIGURATION)
+        router.get(oidcProxyConfig.rootPath() + OidcConstants.WELL_KNOWN_CONFIGURATION)
                 .handler(this::wellKnownConfig);
         if (oidcMetadata.getJsonWebKeySetUri() != null) {
-            router.get(httpRootPath + oidcProxyConfig.rootPath() + oidcProxyConfig.jwksPath()).handler(this::jwks);
+            router.get(oidcProxyConfig.rootPath() + oidcProxyConfig.jwksPath()).handler(this::jwks);
         }
         if (oidcMetadata.getUserInfoUri() != null && oidcProxyConfig.allowIdToken()) {
-            router.get(httpRootPath + oidcProxyConfig.rootPath() + oidcProxyConfig.userInfoPath()).handler(this::userinfo);
+            router.get(oidcProxyConfig.rootPath() + oidcProxyConfig.userInfoPath()).handler(this::userinfo);
         }
-        router.get(httpRootPath + oidcProxyConfig.rootPath() + oidcProxyConfig.authorizationPath()).handler(this::authorize);
-        router.post(httpRootPath + oidcProxyConfig.rootPath() + oidcProxyConfig.tokenPath()).handler(this::token);
+        router.get(oidcProxyConfig.rootPath() + oidcProxyConfig.authorizationPath()).handler(this::authorize);
+        router.post(oidcProxyConfig.rootPath() + oidcProxyConfig.tokenPath()).handler(this::token);
         if (oidcTenantConfig.authentication.redirectPath.isPresent()) {
             if (!oidcProxyConfig.externalRedirectUri().isPresent()) {
                 throw new ConfigurationException("oidc-proxy.external-redirect-uri property must be configured because"

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyRecorder.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyRecorder.java
@@ -15,10 +15,10 @@ public class OidcProxyRecorder {
         this.oidcProxyConfig = oidcProxyConfig;
     }
 
-    public void setupRoutes(BeanContainer beanContainer, RuntimeValue<Router> routerValue, String httpRootPath) {
+    public void setupRoutes(BeanContainer beanContainer, RuntimeValue<Router> routerValue) {
         TenantConfigBean oidcTenantBean = beanContainer.beanInstance(TenantConfigBean.class);
         OidcProxy proxy = new OidcProxy(oidcTenantBean, oidcProxyConfig.getValue());
         Router router = routerValue.getValue();
-        proxy.setup(router, httpRootPath);
+        proxy.setup(router);
     }
 }


### PR DESCRIPTION
Fixes #70 for the `3.15` branch.

Removes the `httpRootPath` prefix from quarkus-oidc-proxy routes as Quarkus already does this automatically.