### PR TITLE
Allow to customize OIDC Proxy metadata route address

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-oidc-proxy.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-oidc-proxy.adoc
@@ -61,6 +61,23 @@ endif::add-copy-button-to-env-var[]
 |`/q/oidc`
 
 
+a| [[quarkus-oidc-proxy_quarkus-oidc-proxy-metadata-path]]`link:#quarkus-oidc-proxy_quarkus-oidc-proxy-metadata-path[quarkus.oidc-proxy.metadata-path]`
+
+
+[.description]
+--
+OIDC proxy metadata path.
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_OIDC_PROXY_METADATA_PATH+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_OIDC_PROXY_METADATA_PATH+++`
+endif::add-copy-button-to-env-var[]
+--|string 
+|`/.well-known/openid-configuration`
+
+
 a| [[quarkus-oidc-proxy_quarkus-oidc-proxy-authorization-path]]`link:#quarkus-oidc-proxy_quarkus-oidc-proxy-authorization-path[quarkus.oidc-proxy.authorization-path]`
 
 

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
@@ -86,7 +86,7 @@ public class OidcProxy {
             throw new ConfigurationException(
                     "Unsupported OIDC service client authentication method");
         }
-        router.get(oidcProxyConfig.rootPath() + OidcConstants.WELL_KNOWN_CONFIGURATION)
+        router.get(oidcProxyConfig.rootPath() + oidcProxyConfig.metadataPath())
                 .handler(this::wellKnownConfig);
         if (oidcMetadata.getJsonWebKeySetUri() != null) {
             router.get(oidcProxyConfig.rootPath() + oidcProxyConfig.jwksPath()).handler(this::jwks);

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyConfig.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyConfig.java
@@ -2,6 +2,7 @@ package io.quarkus.oidc.proxy.runtime;
 
 import java.util.Optional;
 
+import io.quarkus.oidc.common.runtime.OidcConstants;
 import io.quarkus.runtime.annotations.ConfigPhase;
 import io.quarkus.runtime.annotations.ConfigRoot;
 import io.smallrye.config.ConfigMapping;
@@ -22,6 +23,12 @@ public interface OidcProxyConfig {
      */
     @WithDefault("/q/oidc")
     String rootPath();
+
+    /**
+     * OIDC proxy metadata path.
+     */
+    @WithDefault(OidcConstants.WELL_KNOWN_CONFIGURATION)
+    String metadataPath();
 
     /**
      * OIDC proxy authorization endpoint path relative to the {@link #rootPath()}.


### PR DESCRIPTION
Fixes #116.

It allows to configure the metadata path. MCP inspector is capable of falling back to the current default `/.well-known/openid-configuration` but after trying a couple of times to get something out of `/.well-known/oauth-authorization-server`.

Other MCP clients may insist on `/.well-known/oauth-authorization-server` only.

Unfortunately, in order to update one of the integration tests, I'll have to fix https://github.com/quarkusio/quarkus/issues/49668, since `quarkus-oidc` can currently discover the metadata from the `/.well-known/openid-configuration`  only. So if I update the OIDC proxy to have a well-known-config route listen on ` /.well-known/oauth-authorization-server` then the test can not pass, yet.

I'll update one of the integration tests a bit later. 
In the meantime, this simple PR will let me continue playing with the MCP inspector OAuth2 authentication (I'll also need to add a simple route to forward OIDC dynamic client reg requests to Keycloak with #117).