### PR TITLE
Support for additional metadata, authorization and token parameters

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -40,6 +40,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>io.rest-assured</groupId>
+            <artifactId>rest-assured</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-rest-client-oidc-token-propagation-deployment</artifactId>
             <scope>test</scope>

--- a/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
+++ b/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.proxy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.htmlunit.SilentCssErrorHandler;
 import org.htmlunit.TextPage;
@@ -11,6 +12,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class OidcProxyTestCase {
 
@@ -30,6 +35,7 @@ public class OidcProxyTestCase {
     public void testOidcProxy() throws Exception {
 
         try (final WebClient webClient = createWebClient()) {
+
             HtmlPage page = webClient.getPage("http://localhost:8080/web-app");
 
             assertEquals("Sign in to quarkus", page.getTitleText());
@@ -44,8 +50,49 @@ public class OidcProxyTestCase {
             assertEquals("web-app: ID alice, code flow token: Bearer, service: Bearer alice", textPage.getContent());
 
             webClient.getCookieManager().clearCookies();
+
+            checkWellKnownConfig(webClient);
+
         }
 
+    }
+
+    private static void checkWellKnownConfig(WebClient webClient) throws Exception {
+        Response response = RestAssured.when().get("http://localhost:8080/q/oidc/.well-known/openid-configuration");
+        JsonObject json = new JsonObject(response.asString());
+
+        assertEquals("http://localhost:8080/q/oidc/authorize", json.getString("authorization_endpoint"));
+        assertEquals("http://localhost:8080/q/oidc/token", json.getString("token_endpoint"));
+        assertEquals("http://localhost:8080/q/oidc/jwks", json.getString("jwks_uri"));
+        assertEquals("http://localhost:8080/q/oidc/logout", json.getString("end_session_endpoint"));
+        assertEquals("http://localhost:8080/q/oidc/userinfo", json.getString("userinfo_endpoint"));
+        assertEquals("http://localhost:8080/q/oidc/client-registration", json.getString("registration_endpoint"));
+        assertTrue(json.getString("issuer").contains("http://localhost"));
+        assertTrue(json.getString("issuer").contains("/realms/quarkus"));
+
+        checkResponseTypesSupported(json.getJsonArray("response_types_supported"));
+        checkSubjectTypesSupported(json.getJsonArray("subject_types_supported"));
+        checkCodeChallengeMethodsSupported(json.getJsonArray("code_challenge_methods_supported"));
+        checkIdTokenSigningAlorithmsSupported(json.getJsonArray("id_token_signing_alg_values_supported"));
+    }
+
+    private static void checkIdTokenSigningAlorithmsSupported(JsonArray jsonArray) {
+        assertTrue(jsonArray.contains("RS256"));
+        assertTrue(jsonArray.contains("ES256"));
+    }
+
+    private static void checkCodeChallengeMethodsSupported(JsonArray jsonArray) {
+        assertTrue(jsonArray.contains("plain"));
+        assertTrue(jsonArray.contains("S256"));
+    }
+
+    private static void checkSubjectTypesSupported(JsonArray jsonArray) {
+        assertTrue(jsonArray.contains("public"));
+        assertTrue(jsonArray.contains("pairwise"));
+    }
+
+    private static void checkResponseTypesSupported(JsonArray jsonArray) {
+        assertTrue(jsonArray.contains("code"));
     }
 
     private WebClient createWebClient() {


### PR DESCRIPTION
This PR adds support for a few more metadata, authorization, and token request parameters that were required to complete the MCP inspector integration test.

I added a test for the well known metadata handler. 

I think I'd need to add a wiremock based test as well to verify OIDC proxy correctly forwards various parameters, but if possible, I'd rather deal with it separately, to check all forwarded parameters, not only those added with this PR 