### PR TITLE
Add additional authentication params to the redirect URI

### DIFF
--- a/integration-tests/src/main/resources/application.properties
+++ b/integration-tests/src/main/resources/application.properties
@@ -1,5 +1,6 @@
 quarkus.oidc.application-type=hybrid
 quarkus.oidc.logout.post-logout-path=/local-post-logout
+quarkus.oidc.authentication.extra-params.prompt=consent
 
 quarkus.http.auth.permission.logout.paths=/web-app/logout 
 quarkus.http.auth.permission.logout.policy=authenticated

--- a/integration-tests/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
+++ b/integration-tests/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
@@ -1,6 +1,7 @@
 package io.quarkus.oidc.proxy;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -44,6 +45,8 @@ public class OidcProxyTestCase {
             assertTrue(oidcUrl.startsWith("http://localhost:8081/q/oidc/authorize"));
             // `quarkus-oidc` expects the OIDC provider redirect the user back to the protected endpoint
             assertTrue(oidcUrl.contains("redirect_uri=http%3A%2F%2Flocalhost%3A8081%2Fweb-app"));
+            // `quarkus-oidc` does not itself add a `prompt` parameter
+            assertFalse(oidcUrl.contains("prompt="));
             // No OIDC proxy state cookie available yet
             Cookie proxyStateCookie = getProxyStateCookie(webClient);
             assertNull(proxyStateCookie);
@@ -54,6 +57,8 @@ public class OidcProxyTestCase {
             String keycloakUrl = webResponse.getResponseHeaderValue("location");
             assertTrue(keycloakUrl.contains("/protocol/openid-connect/auth"));
             assertTrue(keycloakUrl.contains("redirect_uri=http%3A%2F%2Flocalhost%3A8081%2Flocal-redirect"));
+            // OIDC proxy adds a `prompt=consent` parameter
+            assertTrue(keycloakUrl.contains("prompt=consent"));
 
             // OIDC proxy state cookie must be set by now
             proxyStateCookie = getProxyStateCookie(webClient);

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
@@ -210,6 +210,14 @@ public class OidcProxy {
             codeFlowParams.append("&").append(RESOURCE_INDICATOR).append("=").append(resourceIndicator);
         }
 
+        // Additional parameters
+        if (!oidcTenantConfig.authentication().extraParams().isEmpty()) {
+            for (Map.Entry<String, String> entry : oidcTenantConfig.authentication().extraParams().entrySet()) {
+                codeFlowParams.append("&");
+                codeFlowParams.append(entry.getKey()).append("=").append(OidcCommonUtils.urlEncode(entry.getValue()));
+            }
+        }
+
         String authorizationURL = oidcMetadata.getAuthorizationUri() + "?" + codeFlowParams.toString();
 
         context.response().setStatusCode(HttpResponseStatus.FOUND.code());


### PR DESCRIPTION
While working on the MCP server and OIDC proxy demo, I noticed OIDC proxy does not pick up additional configured authentication parameters such as `prompt=consent`.
The extra parameters are correctly picked up for the logout but not for the authorization.

As far as `prompt=consent` in particular is concerned, it is not actually necessary for Keycloak, because it enforces it by default for the dynamically registered OAuth2 clients, exactly what I need in the demo.
But if it is not Keycloak, OIDC proxy must be able to enforce such requirements as `prompt=consent`, as it will be one of security recommendations in the next blog post related to the MCP security.

I plan to release 0.3.2 immediately after this PR is reviewed/merged