### PR TITLE
fix: respect force-redirect-https-scheme property value

### DIFF
--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
@@ -691,7 +691,8 @@ public class OidcProxy {
 
     private String buildUri(RoutingContext context, String path) {
         final String authority = URI.create(context.request().absoluteURI()).getAuthority();
-        final String scheme = oidcTenantConfig.authentication.forceRedirectHttpsScheme.isPresent() ? "https"
+        final String scheme = oidcTenantConfig.authentication().forceRedirectHttpsScheme().orElse(false)
+                ? "https"
                 : context.request().scheme();
         return new StringBuilder(scheme).append("://")
                 .append(authority)


### PR DESCRIPTION
This PR fixes [#140](https://github.com/quarkiverse/quarkus-oidc-proxy/issues/140)

This PR fixes the incorrect handling of the quarkus.oidc.authentication.force-redirect-https-scheme property.
Currently, the property always forces the HTTPS scheme, regardless of whether it is set to true or false.

The root cause appears to be in the buildUri() method of the OidcProxy class where the logic only checks if the property is present, not its actual boolean value.

With this change:
- If force-redirect-https-scheme=true, HTTPS will be forced.
- If force-redirect-https-scheme=false, the current request’s scheme will be used.
- If the property is not set, the current request’s scheme will also be used.