### PR TITLE
Add a test with a static tenant config

### DIFF
--- a/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyTenantTestCase.java
+++ b/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyTenantTestCase.java
@@ -1,0 +1,110 @@
+package io.quarkus.oidc.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlForm;
+import org.htmlunit.html.HtmlPage;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkus.test.QuarkusDevModeTest;
+import io.restassured.RestAssured;
+import io.restassured.response.Response;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class OidcProxyTenantTestCase {
+
+    private static Class<?>[] testClasses = {
+            OidcServiceResource.class,
+            OidcWebAppResource.class,
+            ServiceApiClient.class
+    };
+
+    @RegisterExtension
+    static final QuarkusDevModeTest test = new QuarkusDevModeTest()
+            .withApplicationRoot((jar) -> jar
+                    .addClasses(testClasses)
+                    .addAsResource("application-tenant.properties", "application.properties"));
+
+    @Test
+    public void testOidcProxy() throws Exception {
+
+        try (final WebClient webClient = createWebClient()) {
+
+            HtmlPage page = webClient.getPage("http://localhost:8080/web-app");
+
+            assertEquals("Sign in to quarkus", page.getTitleText());
+
+            HtmlForm loginForm = page.getForms().get(0);
+
+            loginForm.getInputByName("username").setValueAttribute("alice");
+            loginForm.getInputByName("password").setValueAttribute("alice");
+
+            TextPage textPage = loginForm.getButtonByName("login").click();
+
+            assertEquals("web-app: ID alice, code flow token: Bearer, service: Bearer alice", textPage.getContent());
+
+            webClient.getCookieManager().clearCookies();
+
+            checkWellKnownConfig(webClient);
+
+        }
+
+    }
+
+    private static void checkWellKnownConfig(WebClient webClient) throws Exception {
+        Response response = RestAssured.when().get("http://localhost:8080/q/oidc/.well-known/openid-configuration");
+        JsonObject json = new JsonObject(response.asString());
+
+        assertEquals("http://localhost:8080/q/oidc/authorize", json.getString("authorization_endpoint"));
+        assertEquals("http://localhost:8080/q/oidc/token", json.getString("token_endpoint"));
+        assertEquals("http://localhost:8080/q/oidc/jwks", json.getString("jwks_uri"));
+        assertEquals("http://localhost:8080/q/oidc/logout", json.getString("end_session_endpoint"));
+        assertEquals("http://localhost:8080/q/oidc/userinfo", json.getString("userinfo_endpoint"));
+        assertEquals("http://localhost:8080/q/oidc/client-registration", json.getString("registration_endpoint"));
+        assertTrue(json.getString("issuer").contains("http://localhost"));
+        assertTrue(json.getString("issuer").contains("/realms/quarkus"));
+
+        checkResponseTypesSupported(json.getJsonArray("response_types_supported"));
+        checkSubjectTypesSupported(json.getJsonArray("subject_types_supported"));
+        checkCodeChallengeMethodsSupported(json.getJsonArray("code_challenge_methods_supported"));
+        checkIdTokenSigningAlorithmsSupported(json.getJsonArray("id_token_signing_alg_values_supported"));
+        checkScopesSupported(json.getJsonArray("scopes_supported"));
+    }
+
+    private static void checkIdTokenSigningAlorithmsSupported(JsonArray jsonArray) {
+        assertTrue(jsonArray.contains("RS256"));
+        assertTrue(jsonArray.contains("ES256"));
+    }
+
+    private static void checkCodeChallengeMethodsSupported(JsonArray jsonArray) {
+        assertTrue(jsonArray.contains("plain"));
+        assertTrue(jsonArray.contains("S256"));
+    }
+
+    private static void checkSubjectTypesSupported(JsonArray jsonArray) {
+        assertTrue(jsonArray.contains("public"));
+        assertTrue(jsonArray.contains("pairwise"));
+    }
+
+    private static void checkResponseTypesSupported(JsonArray jsonArray) {
+        assertTrue(jsonArray.contains("code"));
+    }
+
+    private static void checkScopesSupported(JsonArray jsonArray) {
+        assertTrue(jsonArray.contains("openid"));
+        assertTrue(jsonArray.contains("profile"));
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+
+}

--- a/deployment/src/test/resources/application-tenant.properties
+++ b/deployment/src/test/resources/application-tenant.properties
@@ -1,0 +1,15 @@
+
+quarkus.oidc.web-app.auth-server-url=http://localhost:8080/q/oidc
+quarkus.oidc.web-app.client-id=${quarkus.oidc.client-id}
+quarkus.oidc.web-app.credentials.secret=secret
+quarkus.oidc.web-app.application-type=web-app
+quarkus.oidc.web-app.authentication.cookie-path=/web-app
+
+quarkus.rest-client.service-api-client.url=http://localhost:8080/service
+
+quarkus.log.category."org.htmlunit".level=ERROR
+
+quarkus.oidc.tenant.auth-server-url=${quarkus.oidc.auth-server-url}
+quarkus.oidc.tenant.client-id=${quarkus.oidc.client-id}
+
+quarkus.oidc-proxy.tenant-id=tenant


### PR DESCRIPTION
Fixes #184 

The linked issue is caused by the fact that OIDC proxy is not referencing a `keycloak` OIDC tenant configuration, as opposed to the default OIDC tenant configuration.

The added test confirms OIDC proxy `quarkus.oidc-proxy.tenant-id` property can be used to link to non-default OIDC tenant configurations