### PR TITLE
Fix #125: Support a token introspection route

### DIFF
--- a/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
+++ b/deployment/src/test/java/io/quarkus/oidc/proxy/OidcProxyTestCase.java
@@ -68,6 +68,7 @@ public class OidcProxyTestCase {
         assertEquals("http://localhost:8080/q/oidc/userinfo", json.getString("userinfo_endpoint"));
         assertEquals("http://localhost:8080/q/oidc/client-registration", json.getString("registration_endpoint"));
         assertEquals("http://localhost:8080/q/oidc/revoke", json.getString("revocation_endpoint"));
+        assertEquals("http://localhost:8080/q/oidc/introspect", json.getString("introspection_endpoint"));
         assertTrue(json.getString("issuer").contains("http://localhost"));
         assertTrue(json.getString("issuer").contains("/realms/quarkus"));
 

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
@@ -377,22 +377,10 @@ public class OidcProxy {
                                 encodeForm(buffer, RESOURCE_INDICATOR, resourceIndicator);
                             }
                         } else {
-                            // refresh token
-                            String refreshToken = requestParams.get(OidcConstants.REFRESH_TOKEN_VALUE);
-                            if (refreshToken == null) {
-                                LOG.error("Refresh token must be provided");
-                                return badClientRequest(context);
+                            if (!decryptAndEncodeToken(context, requestParams, buffer,
+                                    OidcConstants.REFRESH_TOKEN_VALUE, null)) {
+                                return Uni.createFrom().voidItem();
                             }
-                            if (tokenEncryptionKey != null) {
-                                try {
-                                    refreshToken = OidcUtils.decryptString(refreshToken, tokenDecryptionKey,
-                                            getEncryptionAlgorithm());
-                                } catch (Throwable tex) {
-                                    LOG.error("Refresh token can not be decrypted");
-                                    return serverError(context);
-                                }
-                            }
-                            encodeForm(buffer, OidcConstants.REFRESH_TOKEN_VALUE, refreshToken);
                         }
 
                         Uni<HttpResponse<Buffer>> response = request.sendBuffer(buffer);
@@ -610,26 +598,9 @@ public class OidcProxy {
                             return Uni.createFrom().voidItem();
                         }
 
-                        // token (required)
-                        String token = requestParams.get(OidcConstants.REVOCATION_TOKEN);
-                        if (token == null) {
-                            LOG.error("Token to revoke must be provided");
-                            return badClientRequest(context);
-                        }
-                        if (tokenEncryptionKey != null) {
-                            try {
-                                token = OidcUtils.decryptString(token, tokenDecryptionKey, getEncryptionAlgorithm());
-                            } catch (Throwable tex) {
-                                LOG.error("Token can not be decrypted");
-                                return serverError(context);
-                            }
-                        }
-                        encodeForm(buffer, OidcConstants.REVOCATION_TOKEN, token);
-
-                        // token_type_hint (optional)
-                        String tokenTypeHint = requestParams.get(OidcConstants.REVOCATION_TOKEN_TYPE_HINT);
-                        if (tokenTypeHint != null) {
-                            encodeForm(buffer, OidcConstants.REVOCATION_TOKEN_TYPE_HINT, tokenTypeHint);
+                        if (!decryptAndEncodeToken(context, requestParams, buffer,
+                                OidcConstants.REVOCATION_TOKEN, OidcConstants.REVOCATION_TOKEN_TYPE_HINT)) {
+                            return Uni.createFrom().voidItem();
                         }
 
                         Uni<HttpResponse<Buffer>> response = request.sendBuffer(buffer);
@@ -675,26 +646,9 @@ public class OidcProxy {
                             return Uni.createFrom().voidItem();
                         }
 
-                        // token (required)
-                        String token = requestParams.get(OidcConstants.INTROSPECTION_TOKEN);
-                        if (token == null) {
-                            LOG.error("Token to introspect must be provided");
-                            return badClientRequest(context);
-                        }
-                        if (tokenEncryptionKey != null) {
-                            try {
-                                token = OidcUtils.decryptString(token, tokenDecryptionKey, getEncryptionAlgorithm());
-                            } catch (Throwable tex) {
-                                LOG.error("Token can not be decrypted");
-                                return serverError(context);
-                            }
-                        }
-                        encodeForm(buffer, OidcConstants.INTROSPECTION_TOKEN, token);
-
-                        // token_type_hint (optional)
-                        String tokenTypeHint = requestParams.get(OidcConstants.INTROSPECTION_TOKEN_TYPE_HINT);
-                        if (tokenTypeHint != null) {
-                            encodeForm(buffer, OidcConstants.INTROSPECTION_TOKEN_TYPE_HINT, tokenTypeHint);
+                        if (!decryptAndEncodeToken(context, requestParams, buffer,
+                                OidcConstants.INTROSPECTION_TOKEN, OidcConstants.INTROSPECTION_TOKEN_TYPE_HINT)) {
+                            return Uni.createFrom().voidItem();
                         }
 
                         Uni<HttpResponse<Buffer>> response = request.sendBuffer(buffer);
@@ -729,6 +683,34 @@ public class OidcProxy {
         if (listOfStrings != null) {
             json.put(listPropertyName, listOfStrings);
         }
+    }
+
+    private boolean decryptAndEncodeToken(RoutingContext context, MultiMap requestParams, Buffer buffer,
+            String tokenParam, String tokenTypeHintParam) {
+        String token = requestParams.get(tokenParam);
+        if (token == null) {
+            LOG.errorf("'%s' parameter must be provided", tokenParam);
+            badClientRequest(context);
+            return false;
+        }
+        if (tokenEncryptionKey != null) {
+            try {
+                token = OidcUtils.decryptString(token, tokenDecryptionKey, getEncryptionAlgorithm());
+            } catch (Throwable tex) {
+                LOG.error("Token can not be decrypted");
+                serverError(context);
+                return false;
+            }
+        }
+        encodeForm(buffer, tokenParam, token);
+
+        if (tokenTypeHintParam != null) {
+            String tokenTypeHint = requestParams.get(tokenTypeHintParam);
+            if (tokenTypeHint != null) {
+                encodeForm(buffer, tokenTypeHintParam, tokenTypeHint);
+            }
+        }
+        return true;
     }
 
     private boolean authenticateClient(RoutingContext context, MultiMap requestParams,

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
@@ -157,6 +157,11 @@ public class OidcProxy {
             LOG.debugf("Token revocation route handler path: %s", revocationPath);
             router.post(revocationPath).handler(this::revoke);
         }
+        if (oidcMetadata.getIntrospectionUri() != null) {
+            final String introspectionPath = oidcProxyConfig.rootPath() + oidcProxyConfig.introspectionPath();
+            LOG.debugf("Token introspection route handler path: %s", introspectionPath);
+            router.post(introspectionPath).handler(this::introspect);
+        }
     }
 
     public void authorize(RoutingContext context) {
@@ -513,6 +518,10 @@ public class OidcProxy {
             json.put(OidcConfigurationMetadata.REVOCATION_ENDPOINT,
                     buildUri(context, oidcProxyConfig.rootPath() + oidcProxyConfig.revocationPath()));
         }
+        if (oidcMetadata.getIntrospectionUri() != null) {
+            json.put(OidcConfigurationMetadata.INTROSPECTION_ENDPOINT,
+                    buildUri(context, oidcProxyConfig.rootPath() + oidcProxyConfig.introspectionPath()));
+        }
         if (oidcMetadata.getIssuer() != null) {
             json.put(OidcConfigurationMetadata.ISSUER, oidcMetadata.getIssuer());
         }
@@ -629,6 +638,71 @@ public class OidcProxy {
                                     @Override
                                     public Uni<Void> apply(HttpResponse<Buffer> t, Throwable u) {
                                         LOG.debug("OidcProxy: Token revocation: end");
+                                        context.response().setStatusCode(t.statusCode());
+                                        String body = t.bodyAsString();
+                                        if (body != null && !body.isEmpty()) {
+                                            context.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+                                            context.end(body);
+                                        } else {
+                                            context.response().end();
+                                        }
+                                        return Uni.createFrom().voidItem();
+                                    }
+                                });
+                    }
+
+                }).subscribe().with(new Consumer<Void>() {
+                    @Override
+                    public void accept(Void response) {
+                    }
+                });
+    }
+
+    public void introspect(RoutingContext context) {
+        OidcUtils.getFormUrlEncodedData(context)
+                .onItem().transformToUni(new Function<MultiMap, Uni<? extends Void>>() {
+                    @Override
+                    public Uni<Void> apply(MultiMap requestParams) {
+                        LOG.debug("OidcProxy: Token introspection: start");
+                        HttpRequest<Buffer> request = client.postAbs(oidcMetadata.getIntrospectionUri());
+                        request.putHeader(String.valueOf(HttpHeaders.CONTENT_TYPE), String
+                                .valueOf(HttpHeaders.APPLICATION_X_WWW_FORM_URLENCODED));
+                        request.putHeader(String.valueOf(HttpHeaders.ACCEPT), "application/json");
+
+                        Buffer buffer = Buffer.buffer();
+
+                        if (!authenticateClient(context, requestParams, request, buffer)) {
+                            return Uni.createFrom().voidItem();
+                        }
+
+                        // token (required)
+                        String token = requestParams.get(OidcConstants.INTROSPECTION_TOKEN);
+                        if (token == null) {
+                            LOG.error("Token to introspect must be provided");
+                            return badClientRequest(context);
+                        }
+                        if (tokenEncryptionKey != null) {
+                            try {
+                                token = OidcUtils.decryptString(token, tokenDecryptionKey, getEncryptionAlgorithm());
+                            } catch (Throwable tex) {
+                                LOG.error("Token can not be decrypted");
+                                return serverError(context);
+                            }
+                        }
+                        encodeForm(buffer, OidcConstants.INTROSPECTION_TOKEN, token);
+
+                        // token_type_hint (optional)
+                        String tokenTypeHint = requestParams.get(OidcConstants.INTROSPECTION_TOKEN_TYPE_HINT);
+                        if (tokenTypeHint != null) {
+                            encodeForm(buffer, OidcConstants.INTROSPECTION_TOKEN_TYPE_HINT, tokenTypeHint);
+                        }
+
+                        Uni<HttpResponse<Buffer>> response = request.sendBuffer(buffer);
+                        return response.onItemOrFailure()
+                                .transformToUni(new BiFunction<HttpResponse<Buffer>, Throwable, Uni<? extends Void>>() {
+                                    @Override
+                                    public Uni<Void> apply(HttpResponse<Buffer> t, Throwable u) {
+                                        LOG.debug("OidcProxy: Token introspection: end");
                                         context.response().setStatusCode(t.statusCode());
                                         String body = t.bodyAsString();
                                         if (body != null && !body.isEmpty()) {

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyConfig.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyConfig.java
@@ -77,6 +77,12 @@ public interface OidcProxyConfig {
     String revocationPath();
 
     /**
+     * OIDC proxy token introspection endpoint path relative to the {@link #rootPath()}
+     */
+    @WithDefault("/introspect")
+    String introspectionPath();
+
+    /**
      * Allow to return an ID token from the authorization code grant response.
      */
     @WithDefault("true")


### PR DESCRIPTION
## Summary

- Add a `/q/oidc/introspect` proxy route for OAuth 2.0 Token Introspection (RFC 7662)
- The route accepts POST requests with `token` (required) and `token_type_hint` (optional), authenticates the client, decrypts the token if encryption is enabled, and forwards the request to the OIDC provider's introspection endpoint
- Extract shared client authentication logic into a reusable `authenticateClient()` helper method, used by both `token()` and `introspect()` handlers
- Add `introspection_endpoint` to the `.well-known/openid-configuration` response when the OIDC provider supports it
- Add `quarkus.oidc-proxy.introspection-path` config property (default `/introspect`)

## Test plan

- [x] Introspection endpoint appears in `.well-known/openid-configuration` response (verified via existing well-known config test)
- [x] All 6 deployment tests pass with Keycloak DevServices
- [x] Full reactor build passes with tests