### PR TITLE
Fix #199: Fix potential NPE when parsing Authorization header

### DIFF
--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxy.java
@@ -722,6 +722,11 @@ public class OidcProxy {
         if (authHeader != null) {
             LOG.debug("OidcProxy: Authorization header");
             String[] clientIdAndSecret = getClientIdAndSecretFromAuthorization(authHeader);
+            if (clientIdAndSecret == null) {
+                LOG.error("Authorization header is not valid Basic authentication");
+                badClientRequest(context);
+                return false;
+            }
             clientId = getClientId(clientIdAndSecret[0]);
             clientSecret = clientIdAndSecret[1];
         } else {
@@ -857,9 +862,12 @@ public class OidcProxy {
     }
 
     private String[] getClientIdAndSecretFromAuthorization(String authHeader) {
-        if (authHeader != null && (authHeader.startsWith("Basic") || authHeader.startsWith("Basic"))) {
+        if (authHeader != null && authHeader.regionMatches(true, 0, "Basic ", 0, 6)) {
             String plainIdSecret = new String(Base64.getDecoder().decode(authHeader.substring(6)), StandardCharsets.UTF_8);
-            return plainIdSecret.split(":");
+            String[] parts = plainIdSecret.split(":", 2);
+            if (parts.length == 2) {
+                return parts;
+            }
         }
         return null;
     }


### PR DESCRIPTION
## Summary

- Add null check on the return value of `getClientIdAndSecretFromAuthorization` in `authenticateClient` — previously a non-Basic Authorization header would cause an NPE
- Fix `getClientIdAndSecretFromAuthorization` to validate the decoded credentials contain a colon separator (split with limit 2, check length) — previously a malformed Basic header without a colon would cause `ArrayIndexOutOfBoundsException`
- Use `regionMatches` for case-insensitive "Basic " prefix matching, also fixing the duplicate condition (`startsWith("Basic") || startsWith("Basic")`)

## Test plan

- [x] Full reactor build passes