### PR TITLE
skip when tenant is disabled at runtime

### DIFF
--- a/integration-tests/src/test/java/io/quarkus/oidc/proxy/DisabledOidcTenantProfile.java
+++ b/integration-tests/src/test/java/io/quarkus/oidc/proxy/DisabledOidcTenantProfile.java
@@ -1,0 +1,15 @@
+package io.quarkus.oidc.proxy;
+
+import java.util.Map;
+
+import io.quarkus.test.junit.QuarkusTestProfile;
+
+public class DisabledOidcTenantProfile implements QuarkusTestProfile {
+
+    @Override
+    public Map<String, String> getConfigOverrides() {
+        return Map.of(
+                "quarkus.keycloak.devservices.enabled", "false" // disabling keycloak dev service disables default tenant
+        );
+    }
+}

--- a/integration-tests/src/test/java/io/quarkus/oidc/proxy/DisabledOidcTenantTestCase.java
+++ b/integration-tests/src/test/java/io/quarkus/oidc/proxy/DisabledOidcTenantTestCase.java
@@ -1,0 +1,44 @@
+package io.quarkus.oidc.proxy;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.net.URI;
+
+import org.htmlunit.SilentCssErrorHandler;
+import org.htmlunit.WebClient;
+import org.htmlunit.WebRequest;
+import org.htmlunit.WebResponse;
+import org.junit.jupiter.api.Test;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.TestProfile;
+
+@QuarkusTest
+@TestProfile(DisabledOidcTenantProfile.class)
+public class DisabledOidcTenantTestCase {
+
+    @Test
+    public void testEndpointWhenOidcTenantDisabled() throws Exception {
+        try (final WebClient webClient = createWebClient()) {
+            // Disable auto-redirect
+            webClient.getOptions().setRedirectEnabled(false);
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+
+            // This is the protected endpoint redirect to the OIDC provider which is represented by OIDC proxy
+            WebResponse webResponse = webClient
+                    .loadWebResponse(new WebRequest(URI.create("http://localhost:8081/web-app").toURL()));
+
+            assertNull(webResponse.getResponseHeaderValue("location"),
+                    "Expected no location header from proxy since OIDC tenant is disabled");
+            assertEquals(401, webResponse.getStatusCode(),
+                    "Expected definitive unauthorized response since OIDC tenant to redirect is disabled");
+        }
+    }
+
+    private WebClient createWebClient() {
+        WebClient webClient = new WebClient();
+        webClient.setCssErrorHandler(new SilentCssErrorHandler());
+        return webClient;
+    }
+}

--- a/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyRecorder.java
+++ b/runtime/src/main/java/io/quarkus/oidc/proxy/runtime/OidcProxyRecorder.java
@@ -1,13 +1,18 @@
 package io.quarkus.oidc.proxy.runtime;
 
+import org.jboss.logging.Logger;
+
 import io.quarkus.arc.runtime.BeanContainer;
 import io.quarkus.oidc.runtime.TenantConfigBean;
+import io.quarkus.oidc.runtime.TenantConfigContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.ext.web.Router;
 
 @Recorder
 public class OidcProxyRecorder {
+
+    private static final Logger LOG = Logger.getLogger(OidcProxyRecorder.class);
 
     final RuntimeValue<OidcProxyConfig> oidcProxyConfig;
 
@@ -17,8 +22,16 @@ public class OidcProxyRecorder {
 
     public void setupRoutes(BeanContainer beanContainer, RuntimeValue<Router> routerValue, String httpRootPath) {
         TenantConfigBean oidcTenantBean = beanContainer.beanInstance(TenantConfigBean.class);
-        OidcProxy proxy = new OidcProxy(oidcTenantBean, oidcProxyConfig.getValue(), httpRootPath);
-        Router router = routerValue.getValue();
-        proxy.setup(router);
+        TenantConfigContext tenantConfigContext = oidcProxyConfig.getValue().tenantId().isEmpty()
+                ? oidcTenantBean.getDefaultTenant()
+                : oidcTenantBean.getStaticTenantsConfig().get(oidcProxyConfig.getValue().tenantId().get());
+        if (tenantConfigContext.getOidcTenantConfig().tenantEnabled()) {
+            OidcProxy proxy = new OidcProxy(oidcTenantBean, oidcProxyConfig.getValue(), httpRootPath);
+            Router router = routerValue.getValue();
+            proxy.setup(router);
+        } else {
+            LOG.debugf("Skipping OIDC proxy for the disabled tenant '%s'",
+                    oidcTenantBean.getDefaultTenant().getOidcTenantConfig().clientName().orElse("default"));
+        }
     }
 }


### PR DESCRIPTION
when the proxy is configured but the tenant is disabled at runtime (`quarkus.oidc.tenant-enabled=false`) quarkus fails to start with:
```
java.lang.RuntimeException: java.lang.RuntimeException: Failed to start quarkus

Caused by: java.lang.NullPointerException: Cannot invoke "io.quarkus.oidc.runtime.OidcProviderClientImpl.getWebClient()" because the return value of "io.quarkus.oidc.runtime.TenantConfigContext.getOidcProviderClient()" is null
	at io.quarkus.oidc.proxy.runtime.OidcProxy.<init>(OidcProxy.java:71)
	at io.quarkus.oidc.proxy.runtime.OidcProxyRecorder.setupRoutes(OidcProxyRecorder.java:28)
```

this PR skips creation of `OidcProxy` when the tenant is disabled.